### PR TITLE
Ruby 1.9.2 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ profiles/
 doc/
 \.DS_Store
 .ackrc
+.rvmrc

--- a/lib/ri_cal.rb
+++ b/lib/ri_cal.rb
@@ -1,4 +1,4 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 #
 # The RiCal module provides the outermost namespace, along with several convenience methods for parsing
 # and building calendars and calendar components.

--- a/lib/ri_cal/component.rb
+++ b/lib/ri_cal/component.rb
@@ -1,5 +1,5 @@
 module RiCal
-  #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+  #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
   #
   class Component #:nodoc:
 

--- a/lib/ri_cal/component/alarm.rb
+++ b/lib/ri_cal/component/alarm.rb
@@ -1,7 +1,7 @@
 module RiCal
 
   class Component
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # An Alarm component groups properties defining a reminder or alarm associated with an event or to-do
     # TODO: The Alarm component has complex cardinality restrictions depending on the value of the action property

--- a/lib/ri_cal/component/calendar.rb
+++ b/lib/ri_cal/component/calendar.rb
@@ -1,6 +1,6 @@
 module RiCal
   class Component
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # to see the property accessing methods for this class see the RiCal::Properties::Calendar module
     class Calendar < Component

--- a/lib/ri_cal/component/event.rb
+++ b/lib/ri_cal/component/event.rb
@@ -1,6 +1,6 @@
 module RiCal
   class Component
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # An Event (VEVENT) calendar component groups properties describing a scheduled event.
     # Events may have multiple occurrences

--- a/lib/ri_cal/component/freebusy.rb
+++ b/lib/ri_cal/component/freebusy.rb
@@ -1,6 +1,6 @@
 module RiCal
   class Component
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     #  A Freebusy (VFREEBUSY) calendar component groups properties describing either a request for free/busy time,
     #  a response to a request for free/busy time, or a published set of busy time.

--- a/lib/ri_cal/component/journal.rb
+++ b/lib/ri_cal/component/journal.rb
@@ -1,6 +1,6 @@
 module RiCal
   class Component
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     #  A Journal (VJOURNAL) calendar component groups properties describing a journal entry.
     #  Journals may have multiple occurrences

--- a/lib/ri_cal/component/non_standard.rb
+++ b/lib/ri_cal/component/non_standard.rb
@@ -1,7 +1,7 @@
 module RiCal
 
   class Component
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # An NonStandard component represents a component (or subcomponent) not listed in RFC2445.
     # For example some icalendar data contains VVENUE components, a proposed extension to RFC2445

--- a/lib/ri_cal/component/t_z_info_timezone.rb
+++ b/lib/ri_cal/component/t_z_info_timezone.rb
@@ -1,4 +1,4 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 #
 # A wrapper class for a Timezone implemented by the TZInfo Gem
 # (or by Rails)

--- a/lib/ri_cal/component/timezone.rb
+++ b/lib/ri_cal/component/timezone.rb
@@ -1,6 +1,6 @@
 module RiCal
   class Component
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # An Timezone (VTIMEZONE) calendar component describes a timezone used within the calendar.
     # A Timezone has two or more TimezonePeriod subcomponents which describe the transitions between

--- a/lib/ri_cal/component/timezone/daylight_period.rb
+++ b/lib/ri_cal/component/timezone/daylight_period.rb
@@ -1,7 +1,7 @@
 module RiCal
   class Component
     class Timezone
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       # A DaylightPeriod is a TimezonePeriod during which daylight saving time *is* in effect
       class DaylightPeriod < TimezonePeriod #:nodoc: all

--- a/lib/ri_cal/component/timezone/standard_period.rb
+++ b/lib/ri_cal/component/timezone/standard_period.rb
@@ -1,7 +1,7 @@
 module RiCal
   class Component
     class Timezone
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       # A StandardPeriod is a TimezonePeriod during which daylight saving time is *not* in effect
       class StandardPeriod < TimezonePeriod #:nodoc: all

--- a/lib/ri_cal/component/timezone/timezone_period.rb
+++ b/lib/ri_cal/component/timezone/timezone_period.rb
@@ -1,7 +1,7 @@
 module RiCal
   class Component
     class Timezone
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       # A TimezonePeriod is a component of a timezone representing a period during which a particular offset from UTC is
       # in effect.

--- a/lib/ri_cal/component/todo.rb
+++ b/lib/ri_cal/component/todo.rb
@@ -1,6 +1,6 @@
 module RiCal
   class Component
-    #- ©2009 Rick DeNatale
+    #- c2009 Rick DeNatale
     #- All rights reserved. Refer to the file README.txt for the license
     #
     # A Todo (VTODO) calendar component groups properties describing a to-do

--- a/lib/ri_cal/core_extensions.rb
+++ b/lib/ri_cal/core_extensions.rb
@@ -1,4 +1,4 @@
-#- ©2009 Rick DeNatale
+#- c2009 Rick DeNatale
 #- All rights reserved. Refer to the file README.txt for the license
 #
 

--- a/lib/ri_cal/core_extensions/array.rb
+++ b/lib/ri_cal/core_extensions/array.rb
@@ -1,6 +1,6 @@
 require "ri_cal/core_extensions/array/conversions.rb"
 class Array #:nodoc:
-  #- ©2009 Rick DeNatale
+  #- c2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
   include RiCal::CoreExtensions::Array::Conversions

--- a/lib/ri_cal/core_extensions/array/conversions.rb
+++ b/lib/ri_cal/core_extensions/array/conversions.rb
@@ -1,7 +1,7 @@
 module RiCal
   module CoreExtensions #:nodoc:
     module Array #:nodoc:
-      #- ©2009 Rick DeNatale
+      #- c2009 Rick DeNatale
       #- All rights reserved. Refer to the file README.txt for the license
       #
       module Conversions

--- a/lib/ri_cal/core_extensions/date.rb
+++ b/lib/ri_cal/core_extensions/date.rb
@@ -4,7 +4,7 @@ require "ri_cal/core_extensions/time/calculations.rb"
 require 'date'
 
 class Date #:nodoc:
-  #- ©2009 Rick DeNatale
+  #- c2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
   include RiCal::CoreExtensions::Time::WeekDayPredicates

--- a/lib/ri_cal/core_extensions/date/conversions.rb
+++ b/lib/ri_cal/core_extensions/date/conversions.rb
@@ -1,7 +1,7 @@
 module RiCal
   module CoreExtensions #:nodoc:
     module Date #:nodoc:
-      #- ©2009 Rick DeNatale
+      #- c2009 Rick DeNatale
       #- All rights reserved. Refer to the file README.txt for the license
       #
       module Conversions #:nodoc:

--- a/lib/ri_cal/core_extensions/date_time.rb
+++ b/lib/ri_cal/core_extensions/date_time.rb
@@ -5,7 +5,7 @@ require "ri_cal/core_extensions/time/calculations.rb"
 require 'date'
 
 class DateTime #:nodoc:
-  #- ©2009 Rick DeNatale
+  #- c2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
   include RiCal::CoreExtensions::Time::WeekDayPredicates

--- a/lib/ri_cal/core_extensions/date_time/conversions.rb
+++ b/lib/ri_cal/core_extensions/date_time/conversions.rb
@@ -2,7 +2,7 @@ require 'date'
 module RiCal
   module CoreExtensions #:nodoc:
     module DateTime #:nodoc:
-      #- ©2009 Rick DeNatale
+      #- c2009 Rick DeNatale
       #- All rights reserved. Refer to the file README.txt for the license
       #
       module Conversions #:nodoc:

--- a/lib/ri_cal/core_extensions/object.rb
+++ b/lib/ri_cal/core_extensions/object.rb
@@ -1,7 +1,7 @@
 require "ri_cal/core_extensions/object/conversions.rb"
 
 class Object #:nodoc:
-  #- ©2009 Rick DeNatale
+  #- c2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
   include RiCal::CoreExtensions::Object::Conversions

--- a/lib/ri_cal/core_extensions/object/conversions.rb
+++ b/lib/ri_cal/core_extensions/object/conversions.rb
@@ -1,7 +1,7 @@
 module RiCal
   module CoreExtensions #:nodoc:
     module Object #:nodoc:
-      #- ©2009 Rick DeNatale
+      #- c2009 Rick DeNatale
       #- All rights reserved. Refer to the file README.txt for the license
       #
       module Conversions #:nodoc:

--- a/lib/ri_cal/core_extensions/string.rb
+++ b/lib/ri_cal/core_extensions/string.rb
@@ -1,7 +1,7 @@
 require "ri_cal/core_extensions/string/conversions.rb"
 
 class String #:nodoc:
-  #- ©2009 Rick DeNatale
+  #- c2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
   include RiCal::CoreExtensions::String::Conversions

--- a/lib/ri_cal/core_extensions/string/conversions.rb
+++ b/lib/ri_cal/core_extensions/string/conversions.rb
@@ -1,7 +1,7 @@
 module RiCal
   module CoreExtensions #:nodoc:
     module String #:nodoc:
-      #- ©2009 Rick DeNatale
+      #- c2009 Rick DeNatale
       #- All rights reserved. Refer to the file README.txt for the license
       #
       module Conversions #:nodoc:

--- a/lib/ri_cal/core_extensions/time.rb
+++ b/lib/ri_cal/core_extensions/time.rb
@@ -1,4 +1,4 @@
-#- ©2009 Rick DeNatale
+#- c2009 Rick DeNatale
 #- All rights reserved. Refer to the file README.txt for the license
 #
 require "ri_cal/core_extensions/time/conversions.rb"

--- a/lib/ri_cal/core_extensions/time/calculations.rb
+++ b/lib/ri_cal/core_extensions/time/calculations.rb
@@ -1,7 +1,7 @@
 module RiCal
   module CoreExtensions #:nodoc:
     module Time #:nodoc:
-      #- ©2009 Rick DeNatale
+      #- c2009 Rick DeNatale
       #- All rights reserved. Refer to the file README.txt for the license
       #
       # Provide calculation methods for use by the RiCal gem

--- a/lib/ri_cal/core_extensions/time/conversions.rb
+++ b/lib/ri_cal/core_extensions/time/conversions.rb
@@ -1,7 +1,7 @@
 module RiCal
   module CoreExtensions #:nodoc:
     module Time #:nodoc:
-      #- ©2009 Rick DeNatale
+      #- c2009 Rick DeNatale
       #- All rights reserved. Refer to the file README.txt for the license
       #
       module Conversions

--- a/lib/ri_cal/core_extensions/time/tzid_access.rb
+++ b/lib/ri_cal/core_extensions/time/tzid_access.rb
@@ -1,7 +1,7 @@
 module RiCal
   module CoreExtensions #:nodoc:
     module Time #:nodoc:
-      #- ©2009 Rick DeNatale
+      #- c2009 Rick DeNatale
       #- All rights reserved. Refer to the file README.txt for the license
       #
       # Provides a tzid attribute for ::Time and ::DateTime

--- a/lib/ri_cal/core_extensions/time/week_day_predicates.rb
+++ b/lib/ri_cal/core_extensions/time/week_day_predicates.rb
@@ -1,7 +1,7 @@
 module RiCal
   module CoreExtensions #:nodoc:
     module Time #:nodoc:
-      #- ©2009 Rick DeNatale
+      #- c2009 Rick DeNatale
       #- All rights reserved. Refer to the file README.txt for the license
       #
       # Provide predicate and related methods for use by the RiCal gem

--- a/lib/ri_cal/fast_date_time.rb
+++ b/lib/ri_cal/fast_date_time.rb
@@ -1,5 +1,5 @@
 module RiCal
-  #- ©2009 Rick DeNatale
+  #- c2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
   # FastDateTime mimics the Ruby Standard library DateTime class but avoids the use of Rational

--- a/lib/ri_cal/floating_timezone.rb
+++ b/lib/ri_cal/floating_timezone.rb
@@ -1,5 +1,5 @@
 module RiCal
-  #- ©2009 Rick DeNatale
+  #- c2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
   # FloatingTimezone represents the 'time zone' for a time or date time with no timezone

--- a/lib/ri_cal/invalid_property_value.rb
+++ b/lib/ri_cal/invalid_property_value.rb
@@ -1,5 +1,5 @@
 module RiCal
-  #- ©2009 Rick DeNatale
+  #- c2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
   # An InvalidPropertyValue error is raised when an improper value is assigned to a property

--- a/lib/ri_cal/invalid_timezone_identifier.rb
+++ b/lib/ri_cal/invalid_timezone_identifier.rb
@@ -1,5 +1,5 @@
 module RiCal
-  #- ©2009 Rick DeNatale
+  #- c2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
   # An InvalidTimezoneIdentifier error is raised when a DATETIME property with an invalid timezone is

--- a/lib/ri_cal/occurrence_enumerator.rb
+++ b/lib/ri_cal/occurrence_enumerator.rb
@@ -1,5 +1,5 @@
 module RiCal
-  #- ©2009 Rick DeNatale
+  #- c2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
   # OccurrenceEnumerator provides common methods for CalendarComponents that support recurrence

--- a/lib/ri_cal/parser.rb
+++ b/lib/ri_cal/parser.rb
@@ -1,5 +1,5 @@
 module RiCal
-  #- ©2009 Rick DeNatale
+  #- c2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
   class Parser # :nodoc:

--- a/lib/ri_cal/properties/alarm.rb
+++ b/lib/ri_cal/properties/alarm.rb
@@ -1,6 +1,6 @@
 module RiCal
   module Properties #:nodoc:
-    #- ©2009 Rick DeNatale
+    #- c2009 Rick DeNatale
     #- All rights reserved. Refer to the file README.txt for the license
     #
     # Properties::Alarm provides property accessing methods for the Alarm class

--- a/lib/ri_cal/properties/calendar.rb
+++ b/lib/ri_cal/properties/calendar.rb
@@ -1,6 +1,6 @@
 module RiCal
   module Properties #:nodoc:
-    #- ©2009 Rick DeNatale
+    #- c2009 Rick DeNatale
     #- All rights reserved. Refer to the file README.txt for the license
     #
     # Properties::Calendar provides property accessing methods for the Calendar class

--- a/lib/ri_cal/properties/event.rb
+++ b/lib/ri_cal/properties/event.rb
@@ -1,6 +1,6 @@
 module RiCal
   module Properties #:nodoc:
-    #- ©2009 Rick DeNatale
+    #- c2009 Rick DeNatale
     #- All rights reserved. Refer to the file README.txt for the license
     #
     # Properties::Event provides property accessing methods for the Event class

--- a/lib/ri_cal/properties/freebusy.rb
+++ b/lib/ri_cal/properties/freebusy.rb
@@ -1,6 +1,6 @@
 module RiCal
   module Properties #:nodoc:
-    #- ©2009 Rick DeNatale
+    #- c2009 Rick DeNatale
     #- All rights reserved. Refer to the file README.txt for the license
     #
     # Properties::Freebusy provides property accessing methods for the Freebusy class

--- a/lib/ri_cal/properties/journal.rb
+++ b/lib/ri_cal/properties/journal.rb
@@ -1,6 +1,6 @@
 module RiCal
   module Properties #:nodoc:
-    #- ©2009 Rick DeNatale
+    #- c2009 Rick DeNatale
     #- All rights reserved. Refer to the file README.txt for the license
     #
     # Properties::Journal provides property accessing methods for the Journal class

--- a/lib/ri_cal/properties/timezone.rb
+++ b/lib/ri_cal/properties/timezone.rb
@@ -1,6 +1,6 @@
 module RiCal
   module Properties #:nodoc:
-    #- ©2009 Rick DeNatale
+    #- c2009 Rick DeNatale
     #- All rights reserved. Refer to the file README.txt for the license
     #
     # Properties::Timezone provides property accessing methods for the Timezone class

--- a/lib/ri_cal/properties/timezone_period.rb
+++ b/lib/ri_cal/properties/timezone_period.rb
@@ -1,6 +1,6 @@
 module RiCal
   module Properties #:nodoc:
-    #- ©2009 Rick DeNatale
+    #- c2009 Rick DeNatale
     #- All rights reserved. Refer to the file README.txt for the license
     #
     # Properties::TimezonePeriod provides property accessing methods for the TimezonePeriod class

--- a/lib/ri_cal/properties/todo.rb
+++ b/lib/ri_cal/properties/todo.rb
@@ -1,6 +1,6 @@
 module RiCal
   module Properties #:nodoc:
-    #- ©2009 Rick DeNatale
+    #- c2009 Rick DeNatale
     #- All rights reserved. Refer to the file README.txt for the license
     #
     # Properties::Todo provides property accessing methods for the Todo class

--- a/lib/ri_cal/property_value.rb
+++ b/lib/ri_cal/property_value.rb
@@ -1,5 +1,5 @@
 module RiCal
-  #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+  #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
   #
   # PropertyValue provides common implementation of various RFC 2445 property value types
   class PropertyValue

--- a/lib/ri_cal/property_value/array.rb
+++ b/lib/ri_cal/property_value/array.rb
@@ -1,6 +1,6 @@
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     class Array < PropertyValue # :nodoc:
 

--- a/lib/ri_cal/property_value/cal_address.rb
+++ b/lib/ri_cal/property_value/cal_address.rb
@@ -1,6 +1,6 @@
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # RiCal::PropertyValue::CalAddress represents an icalendar CalAddress property value
     # which is defined in 

--- a/lib/ri_cal/property_value/date.rb
+++ b/lib/ri_cal/property_value/date.rb
@@ -1,7 +1,7 @@
 require 'date'
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # RiCal::PropertyValue::CalAddress represents an icalendar Date property value
     # which is defined in

--- a/lib/ri_cal/property_value/date_time.rb
+++ b/lib/ri_cal/property_value/date_time.rb
@@ -1,7 +1,7 @@
 require 'date'
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # RiCal::PropertyValue::CalAddress represents an icalendar CalAddress property value
     # which is defined in RFC 2445 section 4.3.5 pp 35-37

--- a/lib/ri_cal/property_value/date_time/additive_methods.rb
+++ b/lib/ri_cal/property_value/date_time/additive_methods.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class DateTime
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       # Methods for DateTime which support adding or subtracting another DateTime or Duration
       module AdditiveMethods

--- a/lib/ri_cal/property_value/date_time/time_machine.rb
+++ b/lib/ri_cal/property_value/date_time/time_machine.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class DateTime
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       # Methods for DateTime which support getting values at different point in time.
       module TimeMachine

--- a/lib/ri_cal/property_value/date_time/timezone_support.rb
+++ b/lib/ri_cal/property_value/date_time/timezone_support.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class DateTime
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       # Time zone related methods for DateTime
       module TimezoneSupport

--- a/lib/ri_cal/property_value/duration.rb
+++ b/lib/ri_cal/property_value/duration.rb
@@ -1,6 +1,6 @@
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # RiCal::PropertyValue::CalAddress represents an icalendar Duration property value
     # which is defined in 

--- a/lib/ri_cal/property_value/geo.rb
+++ b/lib/ri_cal/property_value/geo.rb
@@ -1,6 +1,6 @@
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # RiCal::PropertyValue::CalAddress represents an icalendar Duration property value
     # which is defined in 

--- a/lib/ri_cal/property_value/integer.rb
+++ b/lib/ri_cal/property_value/integer.rb
@@ -1,6 +1,6 @@
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     class Integer < PropertyValue # :nodoc:
 

--- a/lib/ri_cal/property_value/occurrence_list.rb
+++ b/lib/ri_cal/property_value/occurrence_list.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     # OccurrenceList is used to represent the value of an RDATE or EXDATE property.
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     class OccurrenceList < Array
       attr_accessor :tzid #:nodoc:

--- a/lib/ri_cal/property_value/period.rb
+++ b/lib/ri_cal/property_value/period.rb
@@ -1,6 +1,6 @@
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # RiCal::PropertyValue::CalAddress represents an icalendar Period property value
     # which is defined in 

--- a/lib/ri_cal/property_value/recurrence_rule.rb
+++ b/lib/ri_cal/property_value/recurrence_rule.rb
@@ -1,6 +1,6 @@
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # RiCal::PropertyValue::RecurrenceRule represents an icalendar Recurrence Rule property value
     # which is defined in 

--- a/lib/ri_cal/property_value/recurrence_rule/enumeration_support_methods.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/enumeration_support_methods.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       module EnumerationSupportMethods # :nodoc:
 

--- a/lib/ri_cal/property_value/recurrence_rule/enumerator.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/enumerator.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class Enumerator # :nodoc:
         # base_time gets changed everytime the time is updated by the recurrence rule's frequency

--- a/lib/ri_cal/property_value/recurrence_rule/initialization_methods.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/initialization_methods.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       module InitializationMethods # :nodoc:
         

--- a/lib/ri_cal/property_value/recurrence_rule/negative_setpos_enumerator.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/negative_setpos_enumerator.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class NegativeSetposEnumerator < Enumerator # :nodoc:
 

--- a/lib/ri_cal/property_value/recurrence_rule/numbered_span.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/numbered_span.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class NumberedSpan # :nodoc:
         attr_reader :source

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
 

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_day_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_day_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class ByDayIncrementer < ListIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_hour_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_hour_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class ByHourIncrementer < ListIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_minute_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_minute_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class ByMinuteIncrementer < ListIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_month_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_month_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class ByMonthIncrementer < ListIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_monthday_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_monthday_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class ByMonthdayIncrementer < ByNumberedDayIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_numbered_day_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_numbered_day_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class ByNumberedDayIncrementer < ListIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_second_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_second_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
          class BySecondIncrementer < ListIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_weekno_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_weekno_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class ByWeekNoIncrementer < ListIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_yearday_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/by_yearday_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class ByYeardayIncrementer < ByNumberedDayIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/daily_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/daily_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class DailyIncrementer < FrequencyIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/frequency_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/frequency_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
 

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/hourly_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/hourly_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class HourlyIncrementer < FrequencyIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/list_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/list_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
 

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/minutely_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/minutely_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class MinutelyIncrementer < FrequencyIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/monthly_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/monthly_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class MonthlyIncrementer < FrequencyIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/null_sub_cycle_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/null_sub_cycle_incrementer.rb
@@ -2,7 +2,7 @@ module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
       class OccurrenceIncrementer # :nodoc:
-        #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+        #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
         #
         class NullSubCycleIncrementer #:nodoc:
           def self.next_time(previous)

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/secondly_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/secondly_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class SecondlyIncrementer < FrequencyIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/weekly_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/weekly_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
         class WeeklyIncrementer < FrequencyIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/yearly_incrementer.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/occurrence_incrementer/yearly_incrementer.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class OccurrenceIncrementer # :nodoc:
          class YearlyIncrementer < FrequencyIncrementer #:nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/recurring_day.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/recurring_day.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       # Instances of RecurringDay are used to represent values in BYDAY recurrence rule parts
       #

--- a/lib/ri_cal/property_value/recurrence_rule/recurring_month_day.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/recurring_month_day.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       # Instances of RecurringMonthDay represent BYMONTHDAY parts in recurrence rules
       class RecurringMonthDay < NumberedSpan # :nodoc:

--- a/lib/ri_cal/property_value/recurrence_rule/recurring_numbered_week.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/recurring_numbered_week.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class RecurringNumberedWeek < NumberedSpan # :nodoc:
         def last

--- a/lib/ri_cal/property_value/recurrence_rule/recurring_year_day.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/recurring_year_day.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       class RecurringYearDay < NumberedSpan # :nodoc:
 

--- a/lib/ri_cal/property_value/recurrence_rule/time_manipulation.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/time_manipulation.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       module TimeManipulation #:nodoc:
 

--- a/lib/ri_cal/property_value/recurrence_rule/validations.rb
+++ b/lib/ri_cal/property_value/recurrence_rule/validations.rb
@@ -1,7 +1,7 @@
 module RiCal
   class PropertyValue
     class RecurrenceRule < PropertyValue
-      #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+      #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
       #
       module Validations #:nodoc:
         # Validate that the parameters of the reciever conform to RFC 2445

--- a/lib/ri_cal/property_value/text.rb
+++ b/lib/ri_cal/property_value/text.rb
@@ -1,6 +1,6 @@
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # RiCal::PropertyValue::Text represents an icalendar Text property value
     # which is defined in 

--- a/lib/ri_cal/property_value/uri.rb
+++ b/lib/ri_cal/property_value/uri.rb
@@ -1,6 +1,6 @@
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # RiCal::PropertyValue::Uri represents an icalendar Uri property value
     # which is defined in 

--- a/lib/ri_cal/property_value/utc_offset.rb
+++ b/lib/ri_cal/property_value/utc_offset.rb
@@ -1,6 +1,6 @@
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     class UtcOffset < PropertyValue # :nodoc:
       attr_accessor :sign, :hours, :minutes, :seconds

--- a/lib/ri_cal/property_value/zulu_date_time.rb
+++ b/lib/ri_cal/property_value/zulu_date_time.rb
@@ -1,7 +1,7 @@
 require 'date'
 module RiCal
   class PropertyValue
-    #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+    #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
     #
     # RiCal::PropertyValue::CalAddress represents an icalendar CalAddress property value
     # which is defined in RFC 2445 section 4.3.5 pp 35-37

--- a/lib/ri_cal/required_timezones.rb
+++ b/lib/ri_cal/required_timezones.rb
@@ -1,5 +1,5 @@
 module RiCal
-  #- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+  #- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
   #
   # RequireTimezones collects the timezones used by a given calendar component or set of calendar components
   # For each timezone we collect it's id, and the earliest and latest times which reference the zone

--- a/parked_specs/ri_cal/claudio_a_bug_spec.rb
+++ b/parked_specs/ri_cal/claudio_a_bug_spec.rb
@@ -1,7 +1,7 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
 require 'rubygems'
-require File.join(File.dirname(__FILE__), %w[.. spec_helper])
+require 'spec_helper'
 
 describe "RiCal TimeZone problem" do
   it "should keep the original calendar timezone intact" do

--- a/spec/ri_cal/bugreports_spec.rb
+++ b/spec/ri_cal/bugreports_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. spec_helper])
+require 'spec_helper'
 
 describe "http://rick_denatale.lighthouseapp.com/projects/30941/tickets/17" do
   it "should parse this" do

--- a/spec/ri_cal/component/alarm_spec.rb
+++ b/spec/ri_cal/component/alarm_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::Component::Alarm do
   

--- a/spec/ri_cal/component/calendar_spec.rb
+++ b/spec/ri_cal/component/calendar_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::Component::Calendar do
 

--- a/spec/ri_cal/component/event_spec.rb
+++ b/spec/ri_cal/component/event_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::Component::Event do
   

--- a/spec/ri_cal/component/freebusy_spec.rb
+++ b/spec/ri_cal/component/freebusy_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::Component::Freebusy do
   

--- a/spec/ri_cal/component/journal_spec.rb
+++ b/spec/ri_cal/component/journal_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::Component::Journal do
   

--- a/spec/ri_cal/component/t_z_info_timezone_spec.rb
+++ b/spec/ri_cal/component/t_z_info_timezone_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 # Uncomment the next two lines to run this spec in textmate
 # require 'rubygems'
 # require 'tzinfo'

--- a/spec/ri_cal/component/timezone_spec.rb
+++ b/spec/ri_cal/component/timezone_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 require 'tzinfo'
 
 describe RiCal::Component::Timezone do

--- a/spec/ri_cal/component/todo_spec.rb
+++ b/spec/ri_cal/component/todo_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::Component::Todo do
   

--- a/spec/ri_cal/component_spec.rb
+++ b/spec/ri_cal/component_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. spec_helper])
+require 'spec_helper'
 require 'tzinfo'
 
 describe RiCal::Component do

--- a/spec/ri_cal/core_extensions/string/conversions_spec.rb
+++ b/spec/ri_cal/core_extensions/string/conversions_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::CoreExtensions::String::Conversions do
   context "#to_ri_cal_date_time_value" do

--- a/spec/ri_cal/core_extensions/time/calculations_spec.rb
+++ b/spec/ri_cal/core_extensions/time/calculations_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::CoreExtensions::Time::Calculations do
 

--- a/spec/ri_cal/core_extensions/time/week_day_predicates_spec.rb
+++ b/spec/ri_cal/core_extensions/time/week_day_predicates_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::CoreExtensions::Time::WeekDayPredicates do
 

--- a/spec/ri_cal/fast_date_time_spec.rb
+++ b/spec/ri_cal/fast_date_time_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. spec_helper])
+require 'spec_helper'
 
 module RiCal
 

--- a/spec/ri_cal/inf_loop_spec.rb
+++ b/spec/ri_cal/inf_loop_spec.rb
@@ -1,7 +1,7 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
 require 'rubygems'
-require File.join(File.dirname(__FILE__), %w[.. spec_helper])
+require 'spec_helper'
 
 describe "an event with unneeded by parts" do
   before(:each) do

--- a/spec/ri_cal/occurrence_enumerator_spec.rb
+++ b/spec/ri_cal/occurrence_enumerator_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. spec_helper.rb])
+require 'spec_helper.rb'
 
 def mock_enumerator(name, next_occurrence)
   mock(name, :next_occurrence => next_occurrence, :bounded? => true, :empty? => false)

--- a/spec/ri_cal/parser_spec.rb
+++ b/spec/ri_cal/parser_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. spec_helper])
+require 'spec_helper'
 
 describe RiCal::Parser do
   

--- a/spec/ri_cal/property_value/date_spec.rb
+++ b/spec/ri_cal/property_value/date_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::PropertyValue::Date do
   context ".advance" do

--- a/spec/ri_cal/property_value/date_time_spec.rb
+++ b/spec/ri_cal/property_value/date_time_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 require 'tzinfo'
 
 describe RiCal::PropertyValue::DateTime do

--- a/spec/ri_cal/property_value/duration_spec.rb
+++ b/spec/ri_cal/property_value/duration_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 require 'date'
 
 describe RiCal::PropertyValue::Duration do

--- a/spec/ri_cal/property_value/occurrence_list_spec.rb
+++ b/spec/ri_cal/property_value/occurrence_list_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::PropertyValue::OccurrenceList do
 

--- a/spec/ri_cal/property_value/period_spec.rb
+++ b/spec/ri_cal/property_value/period_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 # RFC 2445 Section 4.3.9 pp 39-40
 describe RiCal::PropertyValue::Period do

--- a/spec/ri_cal/property_value/recurrence_rule/recurring_year_day_spec.rb
+++ b/spec/ri_cal/property_value/recurrence_rule/recurring_year_day_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::PropertyValue::RecurrenceRule::RecurringYearDay do
 

--- a/spec/ri_cal/property_value/recurrence_rule_spec.rb
+++ b/spec/ri_cal/property_value/recurrence_rule_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 require 'rubygems'
 

--- a/spec/ri_cal/property_value/text_spec.rb
+++ b/spec/ri_cal/property_value/text_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::PropertyValue::Text do
 

--- a/spec/ri_cal/property_value/utc_offset_spec.rb
+++ b/spec/ri_cal/property_value/utc_offset_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. .. spec_helper])
+require 'spec_helper'
 
 describe RiCal::PropertyValue::UtcOffset do
   

--- a/spec/ri_cal/property_value_spec.rb
+++ b/spec/ri_cal/property_value_spec.rb
@@ -1,5 +1,5 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
-require File.join(File.dirname(__FILE__), %w[.. spec_helper])
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+require 'spec_helper'
 require 'tzinfo'
 
 describe RiCal::PropertyValue do

--- a/spec/ri_cal/required_timezones_spec.rb
+++ b/spec/ri_cal/required_timezones_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[.. spec_helper])
+require 'spec_helper'
 
 require 'tzinfo'
 

--- a/spec/ri_cal_spec.rb
+++ b/spec/ri_cal_spec.rb
@@ -1,6 +1,6 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
-require File.join(File.dirname(__FILE__), %w[spec_helper])
+require 'spec_helper'
 
 describe RiCal do
   

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- c2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 
 require File.expand_path(File.join(File.dirname(__FILE__), %w[.. lib ri_cal]))
 require 'cgi'

--- a/tasks/ri_cal.rake
+++ b/tasks/ri_cal.rake
@@ -1,6 +1,6 @@
 #require 'active_support'
 require 'yaml'
-#- ©2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
+#- C2009 Rick DeNatale, All rights reserved. Refer to the file README.txt for the license
 #
 # code stolen from ActiveSupport Gem
 unless  String.instance_methods.include?("camelize")
@@ -167,7 +167,7 @@ class VEntityUpdater
     else
       line_evaluator = "#{type_class(type)}.new(self, line)"
     end
-    
+
     if %w{Array, OccurrenceList}.include?(type)
       ruby_val_parm = "*ruby_value"
       val_parm = "*val"
@@ -360,7 +360,7 @@ class VEntityUpdater
       ruby_out_file.puts("module RiCal")
       ruby_out_file.puts("  module Properties #:nodoc:")
       @indent = "    "
-      ruby_out_file.puts("    #- ©2009 Rick DeNatale")
+      ruby_out_file.puts("    #- c2009 Rick DeNatale")
       ruby_out_file.puts("    #- All rights reserved. Refer to the file README.txt for the license")
       ruby_out_file.puts("    #")
       ruby_out_file.puts("    # Properties::#{module_name} provides property accessing methods for the #{class_name} class")


### PR DESCRIPTION
Just some minor fixes to get ri_cal compatible with 1.9.2. Managed to get a clean run of the specs on 1.9.2 with this.
