### PR TITLE
Parsing error should not raise Exception but rather Error inherited from StandardError

### DIFF
--- a/lib/ri_cal/parser.rb
+++ b/lib/ri_cal/parser.rb
@@ -2,6 +2,8 @@ module RiCal
   #- ©2009 Rick DeNatale
   #- All rights reserved. Refer to the file README.txt for the license
   #
+  class ParseError < StandardError; end
+  
   class Parser # :nodoc:
     attr_reader :last_line_str #:nodoc:
     def next_line #:nodoc:
@@ -87,7 +89,7 @@ module RiCal
     end
 
     def invalid #:nodoc:
-      raise Exception.new("Invalid icalendar file")
+      raise ParseError.new("Invalid icalendar file")      
     end
 
     def still_in(component, separated_line) #:nodoc:

--- a/spec/ri_cal/parser_spec.rb
+++ b/spec/ri_cal/parser_spec.rb
@@ -120,7 +120,7 @@ describe RiCal::Parser do
 
     it "should reject a file which doesn't start with BEGIN" do
       parser = RiCal::Parser.new(StringIO.new("END:VCALENDAR"))
-      lambda {parser.parse}.should raise_error     
+      lambda {parser.parse}.should raise_error(RiCal::ParseError)
     end
 
     describe "parsing an event" do


### PR DESCRIPTION
Hi, just came across an small issue when an ics file cannot be parsed. I think it is better to raise an Error based on StandardError rather than an Exception. For a more elaborate explanation please see here:

http://www.skorks.com/2009/09/ruby-exceptions-and-exception-handling/

Thanks!! Jürgen
