### PR TITLE
Extra colon in x-properties

### DIFF
--- a/lib/ri_cal/component.rb
+++ b/lib/ri_cal/component.rb
@@ -214,7 +214,7 @@ module RiCal
     def export_x_properties_to(export_stream) #:nodoc:
       x_properties.each do |name, props|
         props.each do | prop |
-          export_stream.puts("#{name}:#{prop}")
+          export_stream.puts("#{name}#{prop}")
         end
       end
     end

--- a/spec/ri_cal/component_spec.rb
+++ b/spec/ri_cal/component_spec.rb
@@ -190,6 +190,10 @@ describe RiCal::Component do
       it 'should have an x_wr_calname property with the value "My Personal Calendar"' do
         @it.x_wr_calname.first.should == "My Personal Calendar"
       end
+      
+      it 'should write out the x_wr_calname with the value "My Personal Calendar"' do
+        @it.to_s.should =~ /X-WR-CALNAME:My Personal Calendar/
+      end
 
       context "event with a long description and a dsl built recurence rule" do
         before(:each) do


### PR DESCRIPTION
Hi,

I found a minor bug where an extra colon was being inserted in x-property declarations when calendars are being written to string.

Instead of this:

X-WR-CALNAME:My calendar name

the gem was outputting this:

X-WR-CALNAME::My calendar name

I couldn't get the tests to run, but I think the test in the pull request is passing. :)

Thanks!
