### PR TITLE
Always write both DAYLIGHT and STANDARD periods to VTIMEZONE blocks.

### DIFF
--- a/spec/ri_cal/component/t_z_info_timezone_spec.rb
+++ b/spec/ri_cal/component/t_z_info_timezone_spec.rb
@@ -36,6 +36,62 @@ END:VTIMEZONE
 ENDDATA
   end
 
+  it "should produce an rfc representation that Outlook will not barf on" do
+    tz = RiCal::Component::TZInfoTimezone.new(TZInfo::Timezone.get("America/New_York"))
+    local_first = DateTime.parse("Apr 10, 2007")
+    local_last = DateTime.parse("Apr 16, 2007")
+    utc_first = tz.local_to_utc(local_first)
+    utc_last = tz.local_to_utc(local_last)
+    rez = tz.to_rfc2445_string(utc_first, utc_last)
+    rez.should == <<-ENDDATA
+BEGIN:VTIMEZONE
+TZID;X-RICAL-TZSOURCE=TZINFO:America/New_York
+BEGIN:DAYLIGHT
+DTSTART:20070311T020000
+RDATE:20070311T020000
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+END:DAYLIGHT
+BEGIN:STANDARD
+DTSTART:20071104T020000
+RDATE:20071104T020000
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+TZNAME:EST
+END:STANDARD
+END:VTIMEZONE
+ENDDATA
+  end
+
+  it "should produce an rfc representation that Outlook will not barf on at DST switch" do
+    tz = RiCal::Component::TZInfoTimezone.new(TZInfo::Timezone.get("America/New_York"))
+    local_first = DateTime.parse("Mar 11, 2007 03:00:00 AM")
+    local_last = DateTime.parse("Mar 11, 2007 03:00:00 AM")
+    utc_first = tz.local_to_utc(local_first)
+    utc_last = tz.local_to_utc(local_last)
+    rez = tz.to_rfc2445_string(utc_first, utc_last)
+    rez.should == <<-ENDDATA
+BEGIN:VTIMEZONE
+TZID;X-RICAL-TZSOURCE=TZINFO:America/New_York
+BEGIN:DAYLIGHT
+DTSTART:20070311T020000
+RDATE:20070311T020000
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+END:DAYLIGHT
+BEGIN:STANDARD
+DTSTART:20071104T020000
+RDATE:20071104T020000
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+TZNAME:EST
+END:STANDARD
+END:VTIMEZONE
+ENDDATA
+  end
+
   TZInfo::Timezone.all_identifiers.each do |tz|
     context "TZInfo timezone #{tz}" do
       before(:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), %w[.. lib ri_cal]))
 require 'cgi'
 require 'tzinfo'
 
+alias :context :describe
 
 module Kernel
   if ENV.keys.find {|env_var| env_var.match(/^TM_/)}


### PR DESCRIPTION
Outlook apparently only looks at the STANDARD portion of the VTIMEZONE block. If it doesn't exist, Outlook can't figure out the offsets for the timezone and defaults them to 0. Then Outlook thinks that the local time for the event is many hours off from what it really is. Stoopid Outlook! (Specifically, Outlook 2011 for Mac. I don't have access to any other versions for testing.)

If we put both DAYLIGHT and STANDARD blocks in, the Outlook parses the timezone without problems.
