### PR TITLE
Fix: utf8 safe split for Ruby version major than 1.9

### DIFF
--- a/lib/ri_cal/component/calendar.rb
+++ b/lib/ri_cal/component/calendar.rb
@@ -171,7 +171,7 @@ module RiCal
           stream.string
         end
 
-        if RUBY_VERSION =~ /^1\.9/
+        if RUBY_VERSION >= "1.9"
           def utf8_safe_split(string, n)
             if string.bytesize <= n
               [string, nil]


### PR DESCRIPTION
This fix spec:

RiCal::Component::Calendar RiCal::Component::Calendar::FoldingStream #utf_safe_split should not split a 2-byte utf character
RiCal::Component::Calendar RiCal::Component::Calendar::FoldingStream #utf_safe_split should not split a 3-byte utf character

With Ruby 2.1.0dev (2013-03-02 trunk 39551) [x86_64-linux]

Thanks
