### PR TITLE
Allow empty parameter value

### DIFF
--- a/lib/ri_cal/parser.rb
+++ b/lib/ri_cal/parser.rb
@@ -23,7 +23,7 @@ module RiCal
     def self.parse_params(string) #:nodoc:
       if string
         string.split(";").inject({}) { |result, val|
-          m = /^(.+)=(.+)$/.match(val)
+          m = /^(.+)=(.*)$/.match(val)
           raise "Invalid parameter value #{val.inspect}" unless m
           #TODO - The gsub below is a simplest fix for http://rick_denatale.lighthouseapp.com/projects/30941/tickets/19
           #       it may need further examination if more pathological cases show up.

--- a/spec/ri_cal/parser_spec.rb
+++ b/spec/ri_cal/parser_spec.rb
@@ -22,6 +22,11 @@ describe RiCal::Parser do
     it "should strip surrounding quotes" do
       RiCal::Parser.params_and_value(";TZID=\"(GMT-05.00) Eastern Time (US & Canada)\":20090804T120000").should == [{"TZID" => "(GMT-05.00) Eastern Time (US & Canada)"}, "20090804T120000"]
     end
+    
+    it "should allow empty x-parameter value" do
+      # Example from publicly shared iCloud calendar
+      RiCal::Parser.params_and_value(";X-ADDRESS=:geo:37.334722,-122.008889").should == [{"X-ADDRESS" => ""}, "geo:37.334722,-122.008889"]
+    end
   end
   
   def self.describe_property(entity_name, prop_name, params, value, type = RiCal::PropertyValue::Text)


### PR DESCRIPTION
We’ve encountered an issue when trying to parse shared calendar from iCloud where there’s an empty x-named parameter:

    X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-ADDRESS=;…

RFC 5545 (iCalendar) allows parameter value to be empty as in rule `param-value` in [section 3.1](https://tools.ietf.org/html/rfc5545#section-3.1).