### PR TITLE
Fix warning in hms_to_seconds

### DIFF
--- a/lib/ri_cal/fast_date_time.rb
+++ b/lib/ri_cal/fast_date_time.rb
@@ -121,7 +121,7 @@ module RiCal
     end
 
     def hms_to_seconds(hours, minutes, seconds)
-      seconds + 60 *(minutes + (60 * hours))
+      seconds + 60 * (minutes + (60 * hours))
     end
 
     def seconds_to_hms(total_seconds)


### PR DESCRIPTION
Fixed the following warning that was being generated:

gems/ri_cal-0.8.8/lib/ri_cal/fast_date_time.rb:124: warning: `*' after local variable or literal is interpreted as binary operator
gems/ri_cal-0.8.8/lib/ri_cal/fast_date_time.rb:124: warning: even though it seems like argument prefix